### PR TITLE
Remove bottle :unneeded, which breaks the tap

### DIFF
--- a/Formula/upm.rb
+++ b/Formula/upm.rb
@@ -3,7 +3,6 @@ class Upm < Formula
   desc "Universal package manager: Python, Node.js, Ruby, Emacs Lisp."
   homepage "https://github.com/replit/upm"
   version "1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/replit/upm/releases/download/v1.0/upm_1.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
Attempting to use this tap currently results in an error, due to a deprecation in homebrew, as seen below.

```
==> Tapping replit/tap
Cloning into '/opt/homebrew/Library/Taps/replit/homebrew-tap'...
remote: Enumerating objects: 10, done.
remote: Total 10 (delta 0), reused 0 (delta 0), pack-reused 10
Receiving objects: 100% (10/10), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/replit/homebrew-tap/Formula/upm.rb
upm: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the replit/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/replit/homebrew-tap/Formula/upm.rb:6

Error: Cannot tap replit/tap: invalid syntax in tap!
```

This commit / PR removes `bottle :unneeded`, as it's now unneeded.